### PR TITLE
Add iTerm2-Beta 3.5beta12

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,0 +1,34 @@
+cask "iterm2-beta" do
+    # NOTE: "2" is not a version number, but an intrinsic part of the product name
+    version "3.5.0beta12"
+    sha256 "147ab108da0360a2207fc6382a703de52949340bbfa0caa55d7625a644d22043"
+  
+    url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
+    name "iTerm2"
+    desc "Terminal emulator as alternative to Apple's Terminal app"
+    homepage "https://www.iterm2.com/"
+  
+    livecheck do
+      url "https://iterm2.com/appcasts/testing_modern.xml"
+      strategy :sparkle, &:version
+    end
+  
+    auto_updates true
+    conflicts_with cask: [
+      "iterm2",
+      "iterm2-legacy",
+      "iterm2-nightly",
+    ]
+    depends_on macos: ">= :catalina"
+  
+    app "iTerm.app"
+  
+    zap trash: [
+      "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.googlecode.iterm2.sfl*",
+      "~/Library/Application Support/iTerm",
+      "~/Library/Application Support/iTerm2",
+      "~/Library/Caches/com.googlecode.iterm2",
+      "~/Library/Preferences/com.googlecode.iterm2.plist",
+      "~/Library/Saved Application State/com.googlecode.iterm2.savedState",
+    ]
+  end

--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,34 +1,34 @@
 cask "iterm2-beta" do
-    # NOTE: "2" is not a version number, but an intrinsic part of the product name
-    version "3.5.0beta12"
-    sha256 "147ab108da0360a2207fc6382a703de52949340bbfa0caa55d7625a644d22043"
-  
-    url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
-    name "iTerm2"
-    desc "Terminal emulator as alternative to Apple's Terminal app"
-    homepage "https://www.iterm2.com/"
-  
-    livecheck do
-      url "https://iterm2.com/appcasts/testing_modern.xml"
-      strategy :sparkle, &:version
-    end
-  
-    auto_updates true
-    conflicts_with cask: [
-      "iterm2",
-      "iterm2-legacy",
-      "iterm2-nightly",
-    ]
-    depends_on macos: ">= :catalina"
-  
-    app "iTerm.app"
-  
-    zap trash: [
-      "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.googlecode.iterm2.sfl*",
-      "~/Library/Application Support/iTerm",
-      "~/Library/Application Support/iTerm2",
-      "~/Library/Caches/com.googlecode.iterm2",
-      "~/Library/Preferences/com.googlecode.iterm2.plist",
-      "~/Library/Saved Application State/com.googlecode.iterm2.savedState",
-    ]
+  # NOTE: "2" is not a version number, but an intrinsic part of the product name
+  version "3.5.0beta12"
+  sha256 "147ab108da0360a2207fc6382a703de52949340bbfa0caa55d7625a644d22043"
+
+  url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
+  name "iTerm2"
+  desc "Terminal emulator as alternative to Apple's Terminal app"
+  homepage "https://www.iterm2.com/"
+
+  livecheck do
+    url "https://iterm2.com/appcasts/testing_modern.xml"
+    strategy :sparkle, &:version
   end
+
+  auto_updates true
+  conflicts_with cask: [
+    "iterm2",
+    "iterm2-legacy",
+    "iterm2-nightly"
+  ]
+  depends_on macos: ">= :catalina"
+
+  app "iTerm.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.googlecode.iterm2.sfl*",
+    "~/Library/Application Support/iTerm",
+    "~/Library/Application Support/iTerm2",
+    "~/Library/Caches/com.googlecode.iterm2",
+    "~/Library/Preferences/com.googlecode.iterm2.plist",
+    "~/Library/Saved Application State/com.googlecode.iterm2.savedState"
+  ]
+end


### PR DESCRIPTION
- Add old version of iTerm2 that supports Ventura