### PR TITLE
Fix GitHub Pages Docs for iTerm2 Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is my Homebrew 🍻 Tap where you'll find my custom Casks and Formulae.
 
 ```bash
 brew install laniksj/tap/android-messages-plus
-brew install laniksj/tap/iterm-beta-12
+brew install laniksj/tap/iterm2-beta-12
 ```
 
 or

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
         <h2>
             <a id="Installation" class="anchor" href="#installation" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>💾 Installation</h2>
         <div class="highlight highlight-source-shell">
-            <pre>brew install laniksj/tap/android-messages-plus<br>brew install laniksj/tap/iterm-beta-12</pre>
+            <pre>brew install laniksj/tap/android-messages-plus<br>brew install laniksj/tap/iterm2-beta-12</pre>
             or
             <pre>brew install laniksj/tap/lsusb-plus<br>brew install laniksj/tap/neofetch-plus</pre>
         </div>


### PR DESCRIPTION
- Take care of the typo in the install instructions