### PR TITLE
Add Branch Main as Default Branch

### DIFF
--- a/Formula/lsusb-plus.rb
+++ b/Formula/lsusb-plus.rb
@@ -4,7 +4,7 @@ class LsusbPlus < Formula
   url "https://github.com/LanikSJ/lsusb/archive/refs/tags/1.1.1.tar.gz"
   sha256 "8d3a57cb8387ad53b146119c7863fea86a8312153e1256b6e6e83366b454bbc6"
   license "MIT"
-  head "https://github.com/LanikSJ/lsusb", using: :git
+  head "https://github.com/LanikSJ/lsusb", branch: "main"
 
   depends_on :macos
 


### PR DESCRIPTION
- Fix Brew Audit 
```bash
→ brew audit --strict --new-formula --online lsusb-plus
laniksj/tap/lsusb-plus
  * HEAD: Use `branch: "master"` to specify the default branch
```