### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   Scan-Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/homebrew-tap/security/code-scanning/29](https://github.com/LanikSJ/homebrew-tap/security/code-scanning/29)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required for the `GITHUB_TOKEN`. Since the workflow involves scanning and uploading reports, it likely only needs `contents: read` permissions. This block should be added at the root level of the workflow to apply to all jobs, as none of the jobs have their own `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
