### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 10 1 1 *' # 10:00 AM on January 1
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   action-update-license-year:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/homebrew-tap/security/code-scanning/30](https://github.com/LanikSJ/homebrew-tap/security/code-scanning/30)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, it needs `contents: read` to fetch the repository and `pull-requests: write` to create and merge pull requests. These permissions will be explicitly defined to limit the scope of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
