### PR TITLE
chore(ci): update workflow schedules and add fop-rs to formula bump list

### DIFF
--- a/.github/workflows/bump-casks.yml
+++ b/.github/workflows/bump-casks.yml
@@ -2,7 +2,7 @@ name: Bump Casks
 
 on:
   schedule:
-    # Time is UTC, so below is running everyday at 8AM and 8PM PST
+    # Time is UTC, so below is running everyday at 4AM and 4PM PST
     - cron:  '0 4,16 * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/bump-formula.yml
+++ b/.github/workflows/bump-formula.yml
@@ -1,13 +1,15 @@
 name: Bump Formula
 
+on:
+  schedule:
+    # Time is UTC, so below is running everyday at 5AM and 5PM PST
+    - cron:  '0 5,17 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 permissions:
   contents: read
   pull-requests: write
-
-on:
-  push:
-    tags: ['*']
-  workflow_dispatch:
 
 jobs:
   bump-formula:
@@ -21,5 +23,5 @@ jobs:
           # Bump all outdated casks in this tap
           tap: laniksj/homebrew-tap
           # Bump only these formulae if outdated
-          formula: lsusb-plus
+          formula: fop-rs, lsusb-plus
           livecheck: true


### PR DESCRIPTION
- Changed bump-casks.yml schedule from 8AM/8PM PST to 4AM/4PM PST
- Changed bump-formula.yml trigger from tag pushes to scheduled runs at 5AM/5PM PST
- Added fop-rs to the list of formulas to bump alongside lsusb-plus
- Enabled livecheck for automated version detection