### PR TITLE
chore: update fop-rs to version 5.3.1

### DIFF
--- a/Formula/fop-rs.rb
+++ b/Formula/fop-rs.rb
@@ -1,25 +1,25 @@
 class FopRs < Formula
   desc "Rust-based filter list optimizer for AdBlockers"
   homepage "https://github.com/ryanbr/fop-rs"
-  version "5.3.0"
+  version "5.3.1"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/ryanbr/fop-rs/releases/download/v#{version}/fop-#{version}-macos-arm64"
-      sha256 "6cdfa929a154b1d30fd69500a15de0e82acc0585433ebef3a0fc4cbde15543c4"
+      sha256 "9cdce2b3463f4b81bd13558b3e166a8f1becac41556d8622a5746b4e7278cd45"
     else
       url "https://github.com/ryanbr/fop-rs/releases/download/v#{version}/fop-#{version}-macos-x86_64"
-      sha256 "019e7105e2868ec1fdd5c07be5a2e975768d369f6680edf0682e28c243179300"
+      sha256 "2dc9fd1727b8472986f33625028c318a24f33f6b8582c7a934d4fc2f9fcac313"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/ryanbr/fop-rs/releases/download/v#{version}/fop-#{version}-linux-arm64"
-      sha256 "350b81190df2fc4cecbd488a8fc9470e99cbed3077278526482249a77ae7b146"
+      sha256 "bdefcf52b48cd98439d6d0995696d4673627ef58ce608be60121ec3b8a18d380"
     else
       url "https://github.com/ryanbr/fop-rs/releases/download/v#{version}/fop-#{version}-linux-x86_64"
-      sha256 "fd4f7c26b29cc6a087227473a80991bf623b8ff6365adaa01d0e0200237888af"
+      sha256 "ed3269663c14e91c388bb64138810f07f029ab01518c843f15d8c4c3f46940f3"
     end
   end
 


### PR DESCRIPTION
- Update version and SHA256 checksums for all platform binaries (macOS arm64/x86_64, Linux arm64/x86_64).