### PR TITLE
fix: remove --new flag from brew audit to check all casks instead of only new ones

### DIFF
--- a/.github/workflows/test-cask.yml
+++ b/.github/workflows/test-cask.yml
@@ -72,7 +72,7 @@ jobs:
           for cask in Casks/*.rb; do
             echo "Auditing Cask: $cask"
             cask_name=$(basename "$cask" .rb)
-            brew audit --new --cask "$cask_name" || {
+            brew audit --cask "$cask_name" || {
               echo "Audit failed for $cask"
               exit 1
             }


### PR DESCRIPTION
- remote --new since this isn't a new cask we're testing
