### PR TITLE
chore: update macOS dependency syntax to symbol format in android-messages-plus cask

### DIFF
--- a/Casks/android-messages-plus.rb
+++ b/Casks/android-messages-plus.rb
@@ -16,7 +16,7 @@ cask "android-messages-plus" do
     "android-messages",
     "orangedrangon-android-messages",
   ]
-  depends_on macos: ">= :monterey"
+  depends_on macos: :monterey
 
   app "Android Messages.app"
 


### PR DESCRIPTION
- calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :monterey` instead.
