### PR TITLE
feat(brew): enhance brew-count output and include MAS apps in brew-sync

### DIFF
--- a/cmd/brew-count
+++ b/cmd/brew-count
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 # This script provides the custom Homebrew command `brew count`.
 # It simply counts the number of installed formulae/casks.
-brew list | wc -l
+
+count=$(brew list | wc -l)
+echo "You have $count packages installed."

--- a/cmd/brew-count
+++ b/cmd/brew-count
@@ -2,5 +2,5 @@
 # This script provides the custom Homebrew command `brew count`.
 # It simply counts the number of installed formulae/casks.
 
-count=$(brew list | wc -l)
+count=$(brew list | wc -l |xargs)
 echo "You have $count packages installed."

--- a/cmd/brew-sync
+++ b/cmd/brew-sync
@@ -20,5 +20,5 @@ done
 if [[ $DRY_RUN -eq 1 ]]; then
   echo "dry-run: brew update && brew upgrade"
 else
-  brew update --auto-update && brew upgrade -y && brew cu -ay && brew cleanup -s --prune=1
+  brew update --auto-update && brew upgrade -y && brew cu -ay --include-mas --cleanup && brew cleanup -s --prune=1
 fi


### PR DESCRIPTION
- Updated `brew-count` to store the package count in a variable and display a friendly message ("You have X packages installed.") instead of raw number output.
- Modified `brew-sync` to add `--include-mas --cleanup` flags to `brew cu -ay`, ensuring Mac App Store apps are included and cleaned up during synchronization.
- This improves user feedback and keeps all installed software up‑to‑date.
