### PR TITLE
docs: add Commands and Usage sections, update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@
 - [Description](#-description)
 - [Casks](#-casks)
 - [Formulae](#-formulae)
+- [Commands](#-commands)
 - [Installation](#-installation)
+- [Usage](#-usage)
 - [Bugs](#-bugs)
 - [License](#-license)
 - [Donate](#-donate)
 
 ## 📝 Description
 
-This is my Homebrew 🍻 Tap where you'll find my custom Casks and Formulae.
+This is my Homebrew 🍻 Tap where you'll find my custom Casks, Formulae, and Commands.
 
 ## 🍻 Casks
 
@@ -28,22 +30,60 @@ This is my Homebrew 🍻 Tap where you'll find my custom Casks and Formulae.
 - `fop-rs` 👉 [fop-rs](https://github.com/ryanbr/fop-rs) - Fast, Rust-based filter list optimizer for ad blockers
 - `lsusb-plus` 👉 [lsusb](https://github.com/jlhonora/lsusb) with mods from [jlhonora#23](https://github.com/jlhonora/lsusb/pull/23)
 
+## 🛠 Commands
+
+Custom Homebrew external commands that extend `brew` with additional functionality.
+
+- `brew-count` 👉 Counts the number of installed Homebrew packages (formulae and casks).
+
+  ```bash
+  brew count
+  ```
+
+- `brew-sync` 👉 Updates Homebrew and upgrades all installed packages with a single command. Supports a `--dry-run` flag to preview changes without applying them.
+
+  ```bash
+  brew sync
+  brew sync --dry-run
+  ```
+
 ## 💾 Installation
 
+First, tap the repository:
+
 ```bash
-brew install laniksj/tap/android-messages-plus
+brew tap laniksj/tap
 ```
 
-or
+Then install any cask, formula, or command:
 
 ```bash
-brew install laniksj/tap/fop-rs
+brew install --cask android-messages-plus
 ```
 
-or
+```bash
+brew install fop-rs
+```
 
 ```bash
-brew install laniksj/tap/lsusb-plus
+brew install lsusb-plus
+```
+
+Commands are automatically available once the tap is installed.
+
+## 🛠 Usage
+
+Once installed, use the commands as you would any other `brew` subcommand:
+
+```bash
+# Count installed packages
+brew count
+
+# Sync (update & upgrade) with a dry-run preview
+brew sync --dry-run
+
+# Sync and apply changes
+brew sync
 ```
 
 ## 🐛 Bugs


### PR DESCRIPTION
- Added documentation for `brew-count` and `brew-sync` external commands.
- Updated installation instructions to first tap the repository, then install casks/formulae/commands individually.
- Added a Usage section with examples. Updated the description to mention commands.
- Adjusted the table of contents to include new sections.
