### PR TITLE
refactor: rename brew-* commands and simplify CI tests

### DIFF
--- a/.github/workflows/test-cmd.yml
+++ b/.github/workflows/test-cmd.yml
@@ -45,19 +45,8 @@ jobs:
           brew tap laniksj/tap
 
       # Verify the brew sync cmd exists before running it
-      - name: Test Brew Sync Cmd (conditional)
-        run: |
-          if brew help sync >/dev/null 2>&1; then
-            brew sync --dry-run || true
-          else
-            echo "brew sync cmd not available, skipping"
-          fi
+      - name: Test Count Command
+        run: brew count
 
-      # Verify the brew count cmd exists before running it
-      - name: Test Brew Count Cmd (conditional)
-        run: |
-          if brew help count >/dev/null 2>&1; then
-            brew count
-          else
-            echo "brew count cmd not available, skipping"
-          fi
+      - name: Test Sync Command
+        run: brew sync --dry-run || true

--- a/cmd/count.rb
+++ b/cmd/count.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "abstract_command"
+
 # This script provides the custom Homebrew command `brew count`.
 # It simply counts the number of installed formulae/casks.
 

--- a/cmd/sync.rb
+++ b/cmd/sync.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "abstract_command"
+
 # This script provides a simple sync operation for Homebrew.
 # It updates Homebrew and upgrades installed formulae.
 # Supports a `--dry-run` flag to show what would be executed without making changes.


### PR DESCRIPTION
- Rename cmd/brew-count.rb to cmd/count.rb and cmd/brew-sync.rb to cmd/sync.rb
- Add require "abstract_command" to new command files
- Update CI workflow to run brew count and brew sync directly without conditionals
